### PR TITLE
Updated environment.yml to include SciPy 1.2.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - pandas=0.25.0
   - numpy=1.16.0
   - matplotlib=3.1.1
+  - scipy=1.2.1
   - jupyter=1.0.0
   - jupyter_contrib_nbextensions=0.5.1


### PR DESCRIPTION
SciPy is a dependency of NetworkX, but was not included in the original list of libraries to install in the environment. 
This patch has added one line to the environment.yml file listing SciPy 1.2.1 as a dependency.